### PR TITLE
fix gulp example : missing )

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var ngdoc = require('dgeni-packages/ngdoc');
 gulp.task('docs', function () {
   return gulp.src(['docs/**/*.ngdoc'])
     .pipe(dgeni({packages: [ngdoc]}))
-    .pipe(gulp.dest('build/docs');
+    .pipe(gulp.dest('build/docs'));
 });
 ```
 


### PR DESCRIPTION
In the README , the gulp example was missing a ).